### PR TITLE
Catch "message undefined" type errors

### DIFF
--- a/lib/parseMessage.js
+++ b/lib/parseMessage.js
@@ -31,6 +31,8 @@ function parseTags(messageId, payload) {
             type: messageDef.type,
             tags: tags
         }
+    } else {
+        throw new Error('No message definition with id: ' + messageId);
     }
 }
 


### PR DESCRIPTION
`parseMessage` sometimes returns undefined and the only way it can
return undefined is if `messageDef` is falsey. That means a message
definition could not be found. It looks like all message definitions are
there according to the kegboard protocol so we should throw an error
for undefined message definitions by returning the ID for the message
kegboard emitted.
